### PR TITLE
closes #58 added warn.conflict to a all files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Authors@R: c(
     person("David", "Freedman", role = "ctb"),
     person("F. Hoffmann-La Roche AG", role = c("cph", "fnd")),
     person("Cytel", role = c("cph", "fnd")),
-    person("Pfizer Inc.", role = c("cph", "fnd"))
+    person("Pfizer Inc.", role = c("cph", "fnd")),
+    person("Mahmoud", "Hamza", , "mahmoud.hamza@dataclin.com", role = "ctb")
   )
 Description: A toolbox for programming Clinical Data Standards Interchange
     Consortium (CDISC) compliant Analysis Data Model (ADaM) datasets in R.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,10 +14,10 @@ Authors@R: c(
     person("Pierre", "Wallet", role = "ctb"),
     person("Amin", "Sherzad", role = "ctb"),
     person("David", "Freedman", role = "ctb"),
+    person("Mahmoud", "Hamza", role = "ctb"),
     person("F. Hoffmann-La Roche AG", role = c("cph", "fnd")),
     person("Cytel", role = c("cph", "fnd")),
-    person("Pfizer Inc.", role = c("cph", "fnd")),
-    person("Mahmoud", "Hamza", , "mahmoud.hamza@dataclin.com", role = "ctb")
+    person("Pfizer Inc.", role = c("cph", "fnd"))
   )
 Description: A toolbox for programming Clinical Data Standards Interchange
     Consortium (CDISC) compliant Analysis Data Model (ADaM) datasets in R.

--- a/R/derive_params_growth_age.R
+++ b/R/derive_params_growth_age.R
@@ -97,10 +97,10 @@
 #' @export
 #'
 #' @examples
-#' suppressPackageStartupMessages(library(dplyr))
-#' suppressPackageStartupMessages(library(lubridate))
-#' suppressPackageStartupMessages(library(rlang))
-#' suppressPackageStartupMessages(library(admiral))
+#' library(dplyr, warn.conflicts = FALSE)
+#' library(lubridate, warn.conflicts = FALSE)
+#' library(rlang, warn.conflicts = FALSE)
+#' library(admiral, warn.conflicts = FALSE)
 #'
 #' advs <- dm_peds %>%
 #'   select(USUBJID, BRTHDTC, SEX) %>%

--- a/R/derive_params_growth_age.R
+++ b/R/derive_params_growth_age.R
@@ -97,10 +97,10 @@
 #' @export
 #'
 #' @examples
-#' library(dplyr)
-#' library(lubridate)
-#' library(rlang)
-#' library(admiral)
+#' suppressPackageStartupMessages(library(dplyr))
+#' suppressPackageStartupMessages(library(lubridate))
+#' suppressPackageStartupMessages(library(rlang))
+#' suppressPackageStartupMessages(library(admiral))
 #'
 #' advs <- dm_peds %>%
 #'   select(USUBJID, BRTHDTC, SEX) %>%

--- a/R/derive_params_growth_height.R
+++ b/R/derive_params_growth_height.R
@@ -96,10 +96,10 @@
 #' @export
 #'
 #' @examples
-#' library(dplyr)
-#' library(lubridate)
-#' library(rlang)
-#' library(admiral)
+#' library(dplyr, warn.conflicts = FALSE)
+#' library(lubridate, warn.conflicts = FALSE)
+#' library(rlang, warn.conflicts = FALSE)
+#' library(admiral, warn.conflicts = FALSE)
 #'
 #' advs <- dm_peds %>%
 #'   select(USUBJID, BRTHDTC, SEX) %>%

--- a/man/admiralpeds-package.Rd
+++ b/man/admiralpeds-package.Rd
@@ -37,10 +37,10 @@ Other contributors:
   \item Pierre Wallet [contributor]
   \item Amin Sherzad [contributor]
   \item David Freedman [contributor]
+  \item Mahmoud Hamza [contributor]
   \item F. Hoffmann-La Roche AG [copyright holder, funder]
   \item Cytel [copyright holder, funder]
   \item Pfizer Inc. [copyright holder, funder]
-  \item Mahmoud Hamza \email{mahmoud.hamza@dataclin.com} [contributor]
 }
 
 }

--- a/man/admiralpeds-package.Rd
+++ b/man/admiralpeds-package.Rd
@@ -40,6 +40,7 @@ Other contributors:
   \item F. Hoffmann-La Roche AG [copyright holder, funder]
   \item Cytel [copyright holder, funder]
   \item Pfizer Inc. [copyright holder, funder]
+  \item Mahmoud Hamza \email{mahmoud.hamza@dataclin.com} [contributor]
 }
 
 }

--- a/man/derive_params_growth_age.Rd
+++ b/man/derive_params_growth_age.Rd
@@ -111,10 +111,10 @@ Derive Anthropometric indicators (Z-Scores/Percentiles-for-Age) based on Standar
 for Height/Weight/BMI/Head Circumference by Age
 }
 \examples{
-library(dplyr)
-library(lubridate)
-library(rlang)
-library(admiral)
+suppressPackageStartupMessages(library(dplyr))
+suppressPackageStartupMessages(library(lubridate))
+suppressPackageStartupMessages(library(rlang))
+suppressPackageStartupMessages(library(admiral))
 
 advs <- dm_peds \%>\%
   select(USUBJID, BRTHDTC, SEX) \%>\%

--- a/man/derive_params_growth_age.Rd
+++ b/man/derive_params_growth_age.Rd
@@ -111,10 +111,10 @@ Derive Anthropometric indicators (Z-Scores/Percentiles-for-Age) based on Standar
 for Height/Weight/BMI/Head Circumference by Age
 }
 \examples{
-suppressPackageStartupMessages(library(dplyr))
-suppressPackageStartupMessages(library(lubridate))
-suppressPackageStartupMessages(library(rlang))
-suppressPackageStartupMessages(library(admiral))
+library(dplyr, warn.conflicts = FALSE)
+library(lubridate, warn.conflicts = FALSE)
+library(rlang, warn.conflicts = FALSE)
+library(admiral, warn.conflicts = FALSE)
 
 advs <- dm_peds \%>\%
   select(USUBJID, BRTHDTC, SEX) \%>\%

--- a/man/derive_params_growth_height.Rd
+++ b/man/derive_params_growth_height.Rd
@@ -108,10 +108,10 @@ Derive Anthropometric indicators (Z-Scores/Percentiles-for-Height/Length)
 based on Standard Growth Charts for Weight by Height/Length
 }
 \examples{
-library(dplyr)
-library(lubridate)
-library(rlang)
-library(admiral)
+library(dplyr, warn.conflicts = FALSE)
+library(lubridate, warn.conflicts = FALSE)
+library(rlang, warn.conflicts = FALSE)
+library(admiral, warn.conflicts = FALSE)
 
 advs <- dm_peds \%>\%
   select(USUBJID, BRTHDTC, SEX) \%>\%


### PR DESCRIPTION
According to the [references](https://pharmaverse.github.io/admiralpeds/dev/reference/index.html) page, I found only two user-facing functions for examples. I have suppressed warning for a single function [derive_params_growth_age()](https://pharmaverse.github.io/admiralpeds/dev/reference/derive_params_growth_age.html) only as only this one was showing warning messages in the vignette. Would you like me to change the other function as well? 

Also, do I need to add the suppress message function to internal functions that are not in the vignette? 

Thank you for your Pull Request! We have developed this task checklist from the [Development Process Guide](https://pharmaverse.github.io/admiral/CONTRIBUTING.html#detailed-development-process) to help with the final steps of the process. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the admiral codebase remains robust and consistent.   

Please check off each taskbox as an acknowledgment that you completed the task or check off that it is not relevant to your Pull Request. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `main` branch until you have checked off each task.

- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Run `styler::style_file()` to style R and Rmd files
- [x] Updated relevant unit tests or have written new unit tests, which should consider realistic data scenarios and edge cases, e.g. empty datasets, errors, boundary cases etc. - See [Unit Test Guide](https://pharmaverse.github.io/admiraldev/articles/unit_test_guidance.html#tests-should-be-robust-to-cover-realistic-data-scenarios)
- [x] If you removed/replaced any function and/or function parameters, did you fully follow the [deprecation guidance](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#deprecation)?
- [x] Update to all relevant roxygen headers and examples, including keywords and families. Refer to the [categorization of functions](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#categorization-of-functions) to tag appropriate keyword/family.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Address any updates needed for vignettes and/or templates
- [x] Update `NEWS.md` under the header `# admiralpeds (development version)` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [x] Build admiralpeds site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the Reference page. 
- [x] Address or fix all lintr warnings and errors - `lintr::lint_package()`
- [x] Run `R CMD check` locally and address all errors and warnings - `devtools::check()`
- [x] Link the issue in the Development Section on the right hand side.
- [x] Address all merge conflicts and resolve appropriately
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
